### PR TITLE
remove tanh before exp for MADE, add activation selection for both MADE and coupling layer

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,6 +107,8 @@ num_hidden = {
     'MOONS': 64
 }[args.dataset]
 
+act = 'tanh' if args.dataset is 'GAS' else 'relu'
+
 modules = []
 
 assert args.flow in ['maf', 'glow']
@@ -116,11 +118,11 @@ for _ in range(args.num_blocks):
         modules += [
             fnn.BatchNormFlow(num_inputs),
             fnn.InvertibleMM(num_inputs),
-            fnn.CouplingLayer(num_inputs, num_hidden)
+            fnn.CouplingLayer(num_inputs, num_hidden, s_act='tanh', t_act='relu')
         ]
     elif args.flow == 'maf':
         modules += [
-            fnn.MADE(num_inputs, num_hidden),
+            fnn.MADE(num_inputs, num_hidden, act=act),
             fnn.BatchNormFlow(num_inputs),
             fnn.Reverse(num_inputs)
         ]


### PR DESCRIPTION
Previously we put a tanh on the end of the scale net for MADE, to prevent scale explosion. But in the original implementation the last layer does not have an activation function, instead they have different activation function in the intermediate layers for particular dataset. For coupling layer, the implementation of MAF repo have the scale and translate net apart, and use different activation function for each of those.
This commit is trying to mimic these behaviors.
