### PR TITLE
Correctly saving and loading permutations of the Shuffle() module

### DIFF
--- a/flows.py
+++ b/flows.py
@@ -367,8 +367,8 @@ class Shuffle(nn.Module):
 
     def __init__(self, num_inputs):
         super(Shuffle, self).__init__()
-        self.perm = np.random.permutation(num_inputs)
-        self.inv_perm = np.argsort(self.perm)
+        self.register_buffer("perm", torch.randperm(num_inputs))
+        self.register_buffer("inv_perm", torch.argsort(self.perm))
 
     def forward(self, inputs, cond_inputs=None, mode='direct'):
         if mode == 'direct':


### PR DESCRIPTION
Register perm and inv_perm as buffer in Shuffle(), such that the random permutations are saved and restored by torch.save() and torch.load()